### PR TITLE
Use https in URLs when linking to Wikidata and Wikipedia

### DIFF
--- a/get-last-wikidump.sh
+++ b/get-last-wikidump.sh
@@ -2,6 +2,6 @@ LANG=$1
 FILE=${LANG}wiki-latest-all-titles-in-ns0.gz
 
 rm ${FILE}
-wget http://dumps.wikimedia.org/${LANG}wiki/latest/${FILE}
+wget https://dumps.wikimedia.org/${LANG}wiki/latest/${FILE}
 
 gunzip -f ${FILE}

--- a/mbbot/data/countries.py
+++ b/mbbot/data/countries.py
@@ -268,7 +268,7 @@ wp_country_links['en'] = {
 }
 
 wp_country_links['fr'] = {
-    # http://fr.wikipedia.org/wiki/ISO_3166-1
+    # https://fr.wikipedia.org/wiki/ISO_3166-1
     'Afghanistan': 'AF',
     'Afrique du Sud': 'ZA',
     'Åland': 'AX',
@@ -652,7 +652,7 @@ demonyms['en'] = {
     'Mozambican': 'MZ',
 }
 
-# see http://fr.wikipedia.org/wiki/Liste_de_gentil%C3%A9s
+# see https://fr.wikipedia.org/wiki/Liste_de_gentil%C3%A9s
 
 demonyms['fr'] = {
     'américain': 'US',

--- a/mbbot/data/firstnames.py
+++ b/mbbot/data/firstnames.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# from http://fr.wikipedia.org/wiki/Liste_des_pr%C3%A9noms_fran%C3%A7ais_et_de_la_francophonie
+# from https://fr.wikipedia.org/wiki/Liste_des_pr%C3%A9noms_fran%C3%A7ais_et_de_la_francophonie
 # with local additions
 
 firstname_gender = {}

--- a/mbbot/wp/wikipage.py
+++ b/mbbot/wp/wikipage.py
@@ -88,7 +88,7 @@ class WikiPage(object):
         m = re.match(r'^https?://([a-z\-]+)\.wikipedia\.org/wiki/(.*)$', url)
         page_lang = m.group(1).encode('utf8')
         page_title = urllib.unquote(m.group(2).encode('utf8')).decode('utf8')
-        wp = MediaWiki('http://%s.wikipedia.org/w/api.php' % page_lang)
+        wp = MediaWiki('https://%s.wikipedia.org/w/api.php' % page_lang)
         resp = wp.call({'action': 'query', 'prop': 'pageprops|revisions', 'titles': page_title.encode('utf8'), 'rvprop': 'content'})
         page = resp['query']['pages'].values()[0]
         content = page['revisions'][0].values()[0] if 'revisions' in page else None

--- a/wp_artist_data.py
+++ b/wp_artist_data.py
@@ -65,7 +65,7 @@ WHERE
         ((a.type IS NULL OR a.type = 2) AND (a.begin_date_year IS NULL))
     ) AND
     l.edits_pending = 0 AND
-    u.url LIKE 'http://""" + wp_lang + """.wikipedia.org/wiki/%%'
+    u.url ~ '^https?://""" + wp_lang + """\.wikipedia\.org/wiki/'
     AND a.edits_pending = 0
 ORDER BY b.processed NULLS FIRST, a.id
 LIMIT 750

--- a/wp_artist_viaf.py
+++ b/wp_artist_viaf.py
@@ -43,7 +43,7 @@ WITH
         SELECT DISTINCT a.id AS artist_id, a.gid AS artist_gid, u.url AS wp_url
         FROM artist a
             JOIN l_artist_url l ON l.entity0 = a.id AND l.link IN (SELECT id FROM link WHERE link_type = """ + str(WIKIPEDIA_RELATIONSHIP_TYPES['artist']) + """)
-            JOIN url u ON u.id = l.entity1 AND u.url LIKE 'http://%%.wikipedia.org/wiki/%%' AND substring(u.url from 8 for 2) IN ('en', 'fr')
+            JOIN url u ON u.id = l.entity1 AND u.url ~ '^https?://(en|fr)\.wikipedia\.org/wiki/'
         WHERE 
             /* No existing VIAF relationship */
             NOT EXISTS (SELECT 1 FROM l_artist_url WHERE l_artist_url.entity0 = a.id AND l_artist_url.link IN (SELECT id FROM link WHERE link_type = """ + str(VIAF_RELATIONSHIP_TYPES['artist']) + """))

--- a/wp_links_artists.py
+++ b/wp_links_artists.py
@@ -262,7 +262,7 @@ for artist in db.execute(query, query_params):
                 continue
 
         wp_url = 'http://%s.wikipedia.org/wiki/%s' % (wp_lang, quote_page_title(page_title),)
-        wd_url = 'http://www.wikidata.org/wiki/%s' % wikipage.wikidata_id.upper()
+        wd_url = 'https://www.wikidata.org/wiki/%s' % wikipage.wikidata_id.upper()
         text = 'Wikidata identifier found from matching Wikipedia page %s. The page mentions %s.' % (wp_url, ', '.join(reasons))
         colored_out(bcolors.OKGREEN, ' * linking to %s' % (wd_url,))
         out(' * edit note: %s' % (text,))

--- a/wp_links_artists.py
+++ b/wp_links_artists.py
@@ -20,7 +20,7 @@ db.execute("SET search_path TO musicbrainz, %s" % cfg.BOT_SCHEMA_DB)
 
 wp_lang = sys.argv[1] if len(sys.argv) > 1 else 'en'
 
-wp = MediaWiki('http://%s.wikipedia.org/w/api.php' % wp_lang)
+wp = MediaWiki('https://%s.wikipedia.org/w/api.php' % wp_lang)
 
 suffix = '_' + wp_lang if wp_lang != 'en' else ''
 wps = solr.SolrConnection('http://localhost:8983/solr/wikipedia' + suffix)
@@ -171,7 +171,7 @@ for artist in db.execute(query, query_params):
         if delay < 1.0:
             time.sleep(1.0 - delay)
         last_wp_request = time.time()
-        wikipage = WikiPage.fetch('http://%s.wikipedia.org/wiki/%s' % (wp_lang, title))
+        wikipage = WikiPage.fetch('https://%s.wikipedia.org/wiki/%s' % (wp_lang, title))
         page_orig = wikipage.text
         if not page_orig:
             continue
@@ -261,7 +261,7 @@ for artist in db.execute(query, query_params):
                 colored_out(bcolors.HEADER, ' * artist country (%s) not compatible with wiki language (%s)' % (country, wp_lang))
                 continue
 
-        wp_url = 'http://%s.wikipedia.org/wiki/%s' % (wp_lang, quote_page_title(page_title),)
+        wp_url = 'https://%s.wikipedia.org/wiki/%s' % (wp_lang, quote_page_title(page_title),)
         wd_url = 'https://www.wikidata.org/wiki/%s' % wikipage.wikidata_id.upper()
         text = 'Wikidata identifier found from matching Wikipedia page %s. The page mentions %s.' % (wp_url, ', '.join(reasons))
         colored_out(bcolors.OKGREEN, ' * linking to %s' % (wd_url,))

--- a/wp_links_artists.py
+++ b/wp_links_artists.py
@@ -67,7 +67,7 @@ WITH
         LEFT JOIN iso_3166_1 iso ON iso.area = area.id
         LEFT JOIN (SELECT l.entity0 AS id
             FROM l_artist_url l
-            JOIN url u ON l.entity1 = u.id AND u.url LIKE 'http%%://""" + wp_lang + """.wikipedia.org/wiki/%%'
+            JOIN url u ON l.entity1 = u.id AND u.url ~ '^https?://""" + wp_lang + """\.wikipedia\.org/wiki/'
             WHERE l.link IN (SELECT id FROM link WHERE link_type = 179)
         ) wpl ON wpl.id = a.id
         LEFT JOIN (SELECT l.entity0 AS id

--- a/wp_links_artists_jp.py
+++ b/wp_links_artists_jp.py
@@ -15,7 +15,7 @@ engine = sqlalchemy.create_engine(cfg.MB_DB)
 db = engine.connect()
 db.execute("SET search_path TO musicbrainz")
 
-wp = MediaWiki('http://ja.wikipedia.org/w/api.php')
+wp = MediaWiki('https://ja.wikipedia.org/w/api.php')
 wps = solr.SolrConnection('http://localhost:8983/solr/wikipedia_ja')
 
 mb = MusicBrainzClient(cfg.MB_USERNAME, cfg.MB_PASSWORD, cfg.MB_SITE)

--- a/wp_links_artists_jp.py
+++ b/wp_links_artists_jp.py
@@ -120,7 +120,7 @@ for id, gid, name in db.execute(query):
             continue
         if ratio < min_ratio:
             continue
-        url = 'http://ja.wikipedia.org/wiki/%s' % (quote_page_title(page_title),)
+        url = 'https://ja.wikipedia.org/wiki/%s' % (quote_page_title(page_title),)
         text = 'Matched based on the name. The page mentions %s.' % (join_names('album', found_albums),)
         print ' * linking to %s' % (url,)
         print ' * edit note: %s' % (text,)

--- a/wp_links_artists_ko.py
+++ b/wp_links_artists_ko.py
@@ -15,7 +15,7 @@ engine = sqlalchemy.create_engine(cfg.MB_DB)
 db = engine.connect()
 db.execute("SET search_path TO musicbrainz")
 
-wp = MediaWiki('http://ko.wikipedia.org/w/api.php')
+wp = MediaWiki('https://ko.wikipedia.org/w/api.php')
 wps = solr.SolrConnection('http://localhost:8983/solr/wikipedia_ko')
 
 mb = MusicBrainzClient(cfg.MB_USERNAME, cfg.MB_PASSWORD, cfg.MB_SITE)

--- a/wp_links_artists_ko.py
+++ b/wp_links_artists_ko.py
@@ -120,7 +120,7 @@ for id, gid, name in db.execute(query):
             continue
         #if ratio < min_ratio:
         #    continue
-        url = 'http://ko.wikipedia.org/wiki/%s' % (quote_page_title(page_title),)
+        url = 'https://ko.wikipedia.org/wiki/%s' % (quote_page_title(page_title),)
         text = 'Matched based on the name. The page mentions %s.' % (join_names('album', found_albums),)
         print ' * linking to %s' % (url,)
         print ' * edit note: %s' % (text,)

--- a/wp_links_labels.py
+++ b/wp_links_labels.py
@@ -13,7 +13,7 @@ engine = sqlalchemy.create_engine(cfg.MB_DB)
 db = engine.connect()
 db.execute("SET search_path TO musicbrainz, %s" % cfg.BOT_SCHEMA_DB)
 
-wp = MediaWiki('http://en.wikipedia.org/w/api.php')
+wp = MediaWiki('https://en.wikipedia.org/w/api.php')
 wps = solr.SolrConnection('http://localhost:8983/solr/wikipedia')
 
 mb = MusicBrainzClient(cfg.MB_USERNAME, cfg.MB_PASSWORD, cfg.MB_SITE)

--- a/wp_links_labels.py
+++ b/wp_links_labels.py
@@ -96,7 +96,7 @@ for id, gid, name in db.execute(query):
         print ' * ratio: %s, has artists: %s, found artists: %s' % (ratio, len(artists), len(found_artists))
         if len(found_artists) < 2:
             continue
-        url = 'http://en.wikipedia.org/wiki/%s' % (quote_page_title(page_title),)
+        url = 'https://en.wikipedia.org/wiki/%s' % (quote_page_title(page_title),)
         text = 'Matched based on the name. The page mentions %s.' % (join_names('artist', found_artists),)
         print ' * linking to %s' % (url,)
         print ' * edit note: %s' % (text,)

--- a/wp_links_rgs.py
+++ b/wp_links_rgs.py
@@ -177,7 +177,7 @@ for rg_id, rg_gid, rg_name, ac_name, rg_sec_types, processed in db.execute(query
         auto = ratio > 0.75 and (rg_sec_types is None or ('Compilation' not in rg_sec_types and 'Soundtrack' not in rg_sec_types))
 
         wp_url = 'http://%s.wikipedia.org/wiki/%s' % (wp_lang, quote_page_title(page_title),)
-        wd_url = 'http://www.wikidata.org/wiki/%s' % wikipage.wikidata_id.upper()
+        wd_url = 'https://www.wikidata.org/wiki/%s' % wikipage.wikidata_id.upper()
         text = 'Wikidata identifier found from matching Wikipedia page %s. The page mentions artist "%s" and %s.' % (wp_url, ac_name, join_names('track', found_tracks),)
         colored_out(bcolors.OKGREEN, ' * linking to %s' % (wd_url,))
         out(' * edit note: %s' % (text,))

--- a/wp_links_rgs.py
+++ b/wp_links_rgs.py
@@ -59,7 +59,7 @@ WITH
         FROM release_group rg
         LEFT JOIN (SELECT l.entity0 AS id
             FROM l_release_group_url l
-            JOIN url u ON l.entity1 = u.id AND u.url LIKE 'http%%://""" + wp_lang + """.wikipedia.org/wiki/%%'
+            JOIN url u ON l.entity1 = u.id AND u.url ~ '^https?://""" + wp_lang + """\.wikipedia\.org/wiki/'
             WHERE l.link IN (SELECT id FROM link WHERE link_type = 89)
         ) wpl ON wpl.id = rg.id
         LEFT JOIN (SELECT l.entity0 AS id

--- a/wp_links_rgs.py
+++ b/wp_links_rgs.py
@@ -19,7 +19,7 @@ db.execute("SET search_path TO musicbrainz, %s" % cfg.BOT_SCHEMA_DB)
 
 wp_lang = sys.argv[1] if len(sys.argv) > 1 else 'en'
 
-wp = MediaWiki('http://%s.wikipedia.org/w/api.php' % wp_lang)
+wp = MediaWiki('https://%s.wikipedia.org/w/api.php' % wp_lang)
 
 suffix = '_' + wp_lang if wp_lang != 'en' else ''
 wps = solr.SolrConnection('http://localhost:8983/solr/wikipedia' + suffix)
@@ -118,7 +118,7 @@ for rg_id, rg_gid, rg_name, ac_name, rg_sec_types, processed in db.execute(query
         if delay < 1.0:
             time.sleep(1.0 - delay)
         last_wp_request = time.time()
-        wikipage = WikiPage.fetch('http://%s.wikipedia.org/wiki/%s' % (wp_lang, title))
+        wikipage = WikiPage.fetch('https://%s.wikipedia.org/wiki/%s' % (wp_lang, title))
         page_orig = wikipage.text
         if not page_orig:
             continue
@@ -176,7 +176,7 @@ for rg_id, rg_gid, rg_name, ac_name, rg_sec_types, processed in db.execute(query
             continue
         auto = ratio > 0.75 and (rg_sec_types is None or ('Compilation' not in rg_sec_types and 'Soundtrack' not in rg_sec_types))
 
-        wp_url = 'http://%s.wikipedia.org/wiki/%s' % (wp_lang, quote_page_title(page_title),)
+        wp_url = 'https://%s.wikipedia.org/wiki/%s' % (wp_lang, quote_page_title(page_title),)
         wd_url = 'https://www.wikidata.org/wiki/%s' % wikipage.wikidata_id.upper()
         text = 'Wikidata identifier found from matching Wikipedia page %s. The page mentions artist "%s" and %s.' % (wp_url, ac_name, join_names('track', found_tracks),)
         colored_out(bcolors.OKGREEN, ' * linking to %s' % (wd_url,))

--- a/wp_wikidata_links.py
+++ b/wp_wikidata_links.py
@@ -78,7 +78,7 @@ def main(ENTITY_TYPE):
 
         page = WikiPage.fetch(entity['wp_url'], False)
         if page.wikidata_id:
-            wikidata_url = 'http://www.wikidata.org/wiki/%s' % page.wikidata_id.upper()
+            wikidata_url = 'https://www.wikidata.org/wiki/%s' % page.wikidata_id.upper()
             edit_note = 'From %s' % (entity['wp_url'],)
             colored_out(bcolors.OKGREEN, ' * found Wikidata identifier:', wikidata_url)
             time.sleep(1)

--- a/wp_wikidata_links.py
+++ b/wp_wikidata_links.py
@@ -51,7 +51,7 @@ def main(ENTITY_TYPE):
             SELECT DISTINCT e.id AS entity_id, e.gid AS entity_gid, u.url AS wp_url, substring(u.url from '//(([a-z]|-)+)\\.') as wp_lang
             FROM """ + entity_type_table + """ e
                 JOIN """ + url_relationship_table + """ l ON l.""" + main_entity_entity_point + """ = e.id AND l.link IN (SELECT id FROM link WHERE link_type = """ + str(WIKIPEDIA_RELATIONSHIP_TYPES[ENTITY_TYPE]) + """)
-                JOIN url u ON u.id = l.""" + url_entity_point + """ AND u.url LIKE 'http%%://%%.wikipedia.org/wiki/%%'
+                JOIN url u ON u.id = l.""" + url_entity_point + """ AND u.url ~ '^https?://[a-z-]+\.wikipedia\.org/wiki/'
             WHERE
                 /* No existing Wikidata relationship for this entity */
                 NOT EXISTS (SELECT 1 FROM """ + url_relationship_table + """ ol WHERE ol.""" + main_entity_entity_point + """ = e.id AND ol.link IN (SELECT id FROM link WHERE link_type = """ + str(WIKIDATA_RELATIONSHIP_TYPES[ENTITY_TYPE]) + """))


### PR DESCRIPTION
Wikidata and Wikipedia have switched to https-only (https://blog.wikimedia.org/2015/06/12/securing-wikimedia-sites-with-https/); accesses via http are redirected. The MB client-side code to clean up URLs has been changed to no longer substitute http for http for these URLs, so new URLs are expected to be added using https. The bot, which doesn’t use the JS cleanup, should also submit https URLs.
